### PR TITLE
Added a new public method TypeAdapter.name()

### DIFF
--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.code.gson</groupId>
     <artifactId>gson-parent</artifactId>
-    <version>2.8.1-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gson</artifactId>

--- a/gson/src/main/java/com/google/gson/JsonArray.java
+++ b/gson/src/main/java/com/google/gson/JsonArray.java
@@ -39,7 +39,13 @@ public final class JsonArray extends JsonElement implements Iterable<JsonElement
   public JsonArray() {
     elements = new ArrayList<JsonElement>();
   }
-  
+
+  /**
+   * Initialize the JsonArray expecting to hold the specified number of items
+   *
+   * @param capacity expected capacity of the array
+   * @since 2.9
+   */
   public JsonArray(int capacity) {
     elements = new ArrayList<JsonElement>(capacity);
   }

--- a/gson/src/main/java/com/google/gson/TypeAdapter.java
+++ b/gson/src/main/java/com/google/gson/TypeAdapter.java
@@ -119,6 +119,16 @@ import java.io.Writer;
 public abstract class TypeAdapter<T> {
 
   /**
+   * Returns the value as JSON name
+   *
+   * @param value the Java object to write. May be null.
+   * @since 2.9
+   */
+  public String name(T value) throws IOException {
+    return String.valueOf(value);
+  }
+
+  /**
    * Writes one JSON value (an array, object, string, number, boolean or null)
    * for {@code value}.
    *

--- a/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/MapTypeAdapterFactory.java
@@ -204,7 +204,7 @@ public final class MapTypeAdapterFactory implements TypeAdapterFactory {
       if (!complexMapKeySerialization) {
         out.beginObject();
         for (Map.Entry<K, V> entry : map.entrySet()) {
-          out.name(String.valueOf(entry.getKey()));
+          out.name(keyTypeAdapter.name(entry.getKey()));
           valueTypeAdapter.write(out, entry.getValue());
         }
         out.endObject();

--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapterRuntimeTypeWrapper.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapterRuntimeTypeWrapper.java
@@ -43,7 +43,20 @@ final class TypeAdapterRuntimeTypeWrapper<T> extends TypeAdapter<T> {
 
   @SuppressWarnings({"rawtypes", "unchecked"})
   @Override
+  public String name(T value) throws IOException {
+    TypeAdapter chosen = getChosenAdapter(value);
+    return chosen.name(value);
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  @Override
   public void write(JsonWriter out, T value) throws IOException {
+    TypeAdapter chosen = getChosenAdapter(value);
+    chosen.write(out, value);
+  }
+
+  @SuppressWarnings("rawtypes")
+  private TypeAdapter getChosenAdapter(T value) {
     // Order of preference for choosing type adapters
     // First preference: a type adapter registered for the runtime type
     // Second preference: a type adapter registered for the declared type
@@ -66,7 +79,7 @@ final class TypeAdapterRuntimeTypeWrapper<T> extends TypeAdapter<T> {
         chosen = runtimeTypeAdapter;
       }
     }
-    chosen.write(out, value);
+    return chosen;
   }
 
   /**

--- a/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java
@@ -799,6 +799,10 @@ public final class TypeAdapters {
       return nameToConstant.get(in.nextString());
     }
 
+    @Override public String name(T value) throws IOException {
+      return value == null ? "null" : constantToName.get(value);
+    }
+
     @Override public void write(JsonWriter out, T value) throws IOException {
       out.value(value == null ? null : constantToName.get(value));
     }

--- a/gson/src/test/java/com/google/gson/functional/EnumTest.java
+++ b/gson/src/test/java/com/google/gson/functional/EnumTest.java
@@ -16,6 +16,14 @@
 
 package com.google.gson.functional;
 
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonDeserializationContext;
@@ -28,13 +36,6 @@ import com.google.gson.JsonSerializer;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.common.MoreAsserts;
 import com.google.gson.reflect.TypeToken;
-
-
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.EnumSet;
-import java.util.Set;
 
 import junit.framework.TestCase;
 /**
@@ -198,5 +199,12 @@ public class EnumTest extends TestCase {
 
     @SerializedName("girl")
     FEMALE
+  }
+
+  public void testEnumAsMapKeys() {
+      Map<Gender, String> map = new HashMap<Gender, String>();
+      map.put(Gender.MALE, "Jesse");
+      String json = gson.toJson(map);
+      assertEquals("{\"boy\":\"Jesse\"}", json);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.google.code.gson</groupId>
   <artifactId>gson-parent</artifactId>
-  <version>2.8.1-SNAPSHOT</version>
+  <version>2.9.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Gson Parent</name>


### PR DESCRIPTION
This new method allows a type adapter writer to customize the JSON name.
Previously, we were using String.valueOf() to translate a key to name.
This caused a problem for using enums as keys (If a SerializedName is set, then it is ignored and toString() value is used instead).
This fixes https://github.com/google/gson/issues/1011